### PR TITLE
fix: Increase sleep time between calls to Jupiter API

### DIFF
--- a/src/helpers/solana/getSolanaTokensFromJup.js
+++ b/src/helpers/solana/getSolanaTokensFromJup.js
@@ -36,7 +36,7 @@ async function jupApiGet(path) {
 
 module.exports = async function getSolanaTokensFromJup(currentTokensSet) {
   const tokensWithMarket = await jupApiGet("tokens_with_markets");
-  await sleep(5000);
+  await sleep(305000);
   const tokensVerified = await jupApiGet(
     "tokens?tags=verified,birdeye-trending"
   );


### PR DESCRIPTION
## Description
- Calls to Jupiter API v1 endpoints are now heavily rate limited. In order for the script to perform both calls, the sleep time was increased to 5min (plus a safety buffer)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted the timing of Solana token data retrieval by significantly increasing the post-fetch delay. Users may notice less frequent updates to token lists and related data.
* **Notes**
  * No changes to user interface or functionality controls.
  * Data and prices may take longer to reflect recent changes due to the extended refresh interval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->