### PR TITLE
add monad

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This NPM module and GitHub repo contains SonarWatch's token lists.
 - [Ethereum](https://github.com/sonarwatch/token-lists/releases/latest/download/sonarwatch.ethereum.tokenlist.json)
 - [Gnosis](https://github.com/sonarwatch/token-lists/releases/latest/download/sonarwatch.gnosis.tokenlist.json)
 - [Linea](https://github.com/sonarwatch/token-lists/releases/latest/download/sonarwatch.linea.tokenlist.json)
+- [Monad](https://github.com/Octav-Labs/sw-token-lists/releases/latest/download/sonarwatch.monad.tokenlist.json)
 - [Optimism](https://github.com/sonarwatch/token-lists/releases/latest/download/sonarwatch.optimism.tokenlist.json)
 - [Plasma](https://github.com/Octav-Labs/sw-token-lists/releases/latest/download/sonarwatch.plasma.tokenlist.json)
 - [Plume](https://github.com/Octav-Labs/sw-token-lists/releases/latest/download/sonarwatch.plume.tokenlist.json)

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "build:list:sui": "mkdirp build && node scripts/buildList.js sui > build/sonarwatch.sui.tokenlist.json",
     "build:list:sei": "mkdirp build && node scripts/buildList.js sei > build/sonarwatch.sei.tokenlist.json",
     "build:list:tron": "mkdirp build && node scripts/buildList.js tron > build/sonarwatch.tron.tokenlist.json",
+    "build:list:monad": "mkdirp build && node scripts/buildList.js monad > build/sonarwatch.monad.tokenlist.json",
     "release": "release-it"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build:list:gnosis": "mkdirp build && node scripts/buildList.js gnosis > build/sonarwatch.gnosis.tokenlist.json",
     "build:list:hyperevm": "mkdirp build && node scripts/buildList.js hyperevm > build/sonarwatch.hyperevm.tokenlist.json",
     "build:list:linea": "mkdirp build && node scripts/buildList.js linea > build/sonarwatch.linea.tokenlist.json",
+    "build:list:monad": "mkdirp build && node scripts/buildList.js monad > build/sonarwatch.monad.tokenlist.json",
     "build:list:scroll": "mkdirp build && node scripts/buildList.js scroll > build/sonarwatch.scroll.tokenlist.json",
     "build:list:polygon-zkevm": "mkdirp build && node scripts/buildList.js polygon-zkevm > build/sonarwatch.polygon-zkevm.tokenlist.json",
     "build:list:zksync": "mkdirp build && node scripts/buildList.js zksync > build/sonarwatch.zksync.tokenlist.json",
@@ -33,7 +34,6 @@
     "build:list:sui": "mkdirp build && node scripts/buildList.js sui > build/sonarwatch.sui.tokenlist.json",
     "build:list:sei": "mkdirp build && node scripts/buildList.js sei > build/sonarwatch.sei.tokenlist.json",
     "build:list:tron": "mkdirp build && node scripts/buildList.js tron > build/sonarwatch.tron.tokenlist.json",
-    "build:list:monad": "mkdirp build && node scripts/buildList.js monad > build/sonarwatch.monad.tokenlist.json",
     "release": "release-it"
   },
   "files": [

--- a/scripts/buildLists.js
+++ b/scripts/buildLists.js
@@ -8,6 +8,7 @@ const cronosList = require("../build/sonarwatch.cronos.tokenlist.json");
 const gnosisList = require("../build/sonarwatch.gnosis.tokenlist.json");
 const hyperevmList = require("../build/sonarwatch.hyperevm.tokenlist.json");
 const lineaList = require("../build/sonarwatch.linea.tokenlist.json");
+const monadList = require("../build/sonarwatch.monad.tokenlist.json");
 const scrollList = require("../build/sonarwatch.scroll.tokenlist.json");
 const zksyncList = require("../build/sonarwatch.zksync.tokenlist.json");
 const polygonZkEvmList = require("../build/sonarwatch.polygon-zkevm.tokenlist.json");
@@ -22,7 +23,6 @@ const starknetList = require("../build/sonarwatch.starknet.tokenlist.json");
 const suiList = require("../build/sonarwatch.sui.tokenlist.json");
 const seiList = require("../build/sonarwatch.sei.tokenlist.json");
 const tronList = require("../build/sonarwatch.tron.tokenlist.json");
-const monadList = require("../build/sonarwatch.monad.tokenlist.json");
 
 const lists = {
   aptos: aptosList,
@@ -35,6 +35,7 @@ const lists = {
   gnosis: gnosisList,
   hyperevm: hyperevmList,
   linea: lineaList,
+  monad: monadList,
   scroll: scrollList,
   zksync: zksyncList,
   "polygon-zkevm": polygonZkEvmList,
@@ -49,6 +50,5 @@ const lists = {
   sui: suiList,
   sei: seiList,
   tron: tronList,
-  monad: monadList,
 };
 console.log(JSON.stringify(lists));

--- a/scripts/buildLists.js
+++ b/scripts/buildLists.js
@@ -22,6 +22,7 @@ const starknetList = require("../build/sonarwatch.starknet.tokenlist.json");
 const suiList = require("../build/sonarwatch.sui.tokenlist.json");
 const seiList = require("../build/sonarwatch.sei.tokenlist.json");
 const tronList = require("../build/sonarwatch.tron.tokenlist.json");
+const monadList = require("../build/sonarwatch.monad.tokenlist.json");
 
 const lists = {
   aptos: aptosList,
@@ -48,5 +49,6 @@ const lists = {
   sui: suiList,
   sei: seiList,
   tron: tronList,
+  monad: monadList,
 };
 console.log(JSON.stringify(lists));

--- a/src/assets/listStaticConfigs.json
+++ b/src/assets/listStaticConfigs.json
@@ -78,6 +78,14 @@
     "logoURI": "https://raw.githubusercontent.com/sonarwatch/token-lists/main/images/lists/sw_none.png",
     "rpcEndpoint": "https://1rpc.io/linea"
   },
+  "monad": {
+    "id": "monad",
+    "name": "Monad",
+    "addressType": "evm",
+    "chainId": 143,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/38927/large/mon.png",
+    "rpcEndpoint": "https://rpc.monad.xyz"
+  },
   "scroll": {
     "id": "scroll",
     "name": "Scroll",
@@ -186,13 +194,5 @@
     "addressType": "tron",
     "chainId": 728126428,
     "logoURI": "https://assets.coingecko.com/coins/images/1094/standard/tron-logo.png"
-  },
-  "monad": {
-    "id": "monad",
-    "name": "Monad",
-    "addressType": "evm",
-    "chainId": 143,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/38927/large/mon.png",
-    "rpcEndpoint": "https://rpc.monad.xyz"
   }
 }

--- a/src/assets/listStaticConfigs.json
+++ b/src/assets/listStaticConfigs.json
@@ -186,5 +186,13 @@
     "addressType": "tron",
     "chainId": 728126428,
     "logoURI": "https://assets.coingecko.com/coins/images/1094/standard/tron-logo.png"
+  },
+  "monad": {
+    "id": "monad",
+    "name": "Monad",
+    "addressType": "evm",
+    "chainId": 143,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/38927/large/mon.png",
+    "rpcEndpoint": "https://rpc.monad.xyz"
   }
 }

--- a/src/generateTokens.js
+++ b/src/generateTokens.js
@@ -23,6 +23,7 @@ const tokenGenerators = {
   gnosis: () => getEvmTokens("gnosis"),
   hyperevm: () => getEvmTokens("hyperevm"),
   linea: () => getEvmTokens("linea"),
+  monad: () => getEvmTokens("monad"),
   scroll: () => getEvmTokens("scroll"),
   zksync: () => zksyncTokens,
   "polygon-zkevm": () => getEvmTokens("polygon-zkevm"),
@@ -37,7 +38,6 @@ const tokenGenerators = {
   sui: () => getSuiTokens(),
   sei: () => seiTokens,
   tron: () => getTronTokens(),
-  monad: () => getEvmTokens("monad"),
 };
 
 // const currentTokenGenerators = {

--- a/src/generateTokens.js
+++ b/src/generateTokens.js
@@ -37,6 +37,7 @@ const tokenGenerators = {
   sui: () => getSuiTokens(),
   sei: () => seiTokens,
   tron: () => getTronTokens(),
+  monad: () => getEvmTokens("monad"),
 };
 
 // const currentTokenGenerators = {

--- a/src/helpers/coingeckoPlatformFromNetworkId.js
+++ b/src/helpers/coingeckoPlatformFromNetworkId.js
@@ -22,6 +22,7 @@ const platforms = {
   sui: "sui",
   sei: "sei",
   tron: "tron",
+  monad: "monad",
 };
 
 module.exports = function coingeckoPlatformFromNetworkId(networkId) {

--- a/src/helpers/coingeckoPlatformFromNetworkId.js
+++ b/src/helpers/coingeckoPlatformFromNetworkId.js
@@ -8,6 +8,7 @@ const platforms = {
   gnosis: "xdai",
   hyperevm: "hyperevm",
   linea: "linea",
+  monad: "monad",
   scroll: "scroll",
   zksync: "zksync",
   "polygon-zkevm": "polygon-zkevm",
@@ -22,7 +23,6 @@ const platforms = {
   sui: "sui",
   sei: "sei",
   tron: "tron",
-  monad: "monad",
 };
 
 module.exports = function coingeckoPlatformFromNetworkId(networkId) {

--- a/src/helpers/getTokensFromCurrentList.js
+++ b/src/helpers/getTokensFromCurrentList.js
@@ -1,6 +1,9 @@
 const { default: axios } = require("axios");
 
 module.exports = async function getTokensFromCurrentList(networkId) {
+  // temp till we have a list
+  if (networkId === "monad") return [];
+
   let currentList = await axios
     .get(
       `https://github.com/Octav-Labs/sw-token-lists/releases/latest/download/sonarwatch.${networkId}.tokenlist.json`,

--- a/src/helpers/getTokensFromList.js
+++ b/src/helpers/getTokensFromList.js
@@ -8,6 +8,7 @@ const cronosTokens = require("../tokens/cronos.json");
 const gnosisTokens = require("../tokens/gnosis.json");
 const hyperevmTokens = require("../tokens/hyperevm.json");
 const lineaTokens = require("../tokens/linea.json");
+const monadTokens = require("../tokens/monad.json");
 const scrollTokens = require("../tokens/scroll.json");
 const zksyncTokens = require("../tokens/zksync.json");
 const polygonZkEvmTokens = require("../tokens/polygon-zkevm.json");
@@ -21,7 +22,6 @@ const starknetTokens = require("../tokens/starknet.json");
 const suiTokens = require("../tokens/sui.json");
 const seiTokens = require("../tokens/sei.json");
 const tronTokens = require("../tokens/tron.json");
-const monadTokens = require("../tokens/monad.json");
 const ethereumTokens = require("../tokens/ethereum.json");
 
 const lists = {
@@ -35,6 +35,7 @@ const lists = {
   gnosis: gnosisTokens,
   hyperevm: hyperevmTokens,
   linea: lineaTokens,
+  monad: monadTokens,
   scroll: scrollTokens,
   zksync: zksyncTokens,
   "polygon-zkevm": polygonZkEvmTokens,
@@ -49,7 +50,6 @@ const lists = {
   sui: suiTokens,
   sei: seiTokens,
   tron: tronTokens,
-  monad: monadTokens,
 };
 
 module.exports = function getTokensFromList(networkId) {

--- a/src/helpers/getTokensFromList.js
+++ b/src/helpers/getTokensFromList.js
@@ -21,6 +21,7 @@ const starknetTokens = require("../tokens/starknet.json");
 const suiTokens = require("../tokens/sui.json");
 const seiTokens = require("../tokens/sei.json");
 const tronTokens = require("../tokens/tron.json");
+const monadTokens = require("../tokens/monad.json");
 const ethereumTokens = require("../tokens/ethereum.json");
 
 const lists = {
@@ -48,6 +49,7 @@ const lists = {
   sui: suiTokens,
   sei: seiTokens,
   tron: tronTokens,
+  monad: monadTokens,
 };
 
 module.exports = function getTokensFromList(networkId) {

--- a/src/tokens/monad.json
+++ b/src/tokens/monad.json
@@ -1,0 +1,26 @@
+[
+  {
+    "chainId": 143,
+    "address": "0x0000000000000000000000000000000000000000",
+    "decimals": 18,
+    "name": "Monad",
+    "symbol": "MON",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/38927/large/mon.png",
+    "tags": ["native"],
+    "extensions": {
+      "coingeckoId": "monad"
+    }
+  },
+  {
+    "chainId": 143,
+    "address": "0x3bd359C1119dA7Da1D913D1C4D2B7c461115433A",
+    "decimals": 18,
+    "name": "Wrapped MON",
+    "symbol": "WMON",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/70784/large/wmon.png",
+    "tags": ["wnative"],
+    "extensions": {
+      "coingeckoId": "wrapped-monad"
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- Wires up Monad (EVM, chainId 143) following the same pattern used for HyperEVM/Sonic/Tron: static config, token generator, CoinGecko platform mapping, schema resolution (evm), build script/list aggregation.
- Seeds `src/tokens/monad.json` with the native MON token and Wrapped MON (WMON, checksummed address, verified against CoinGecko's `wrapped-monad` entry).
- Remaining tokens will be pulled automatically from CoinGecko on the next full `npm run build:list:monad` run (same mechanism as every other EVM list).

## Test plan
- [x] `node` smoke test loading `listStaticConfigs.monad` + `src/tokens/monad.json` through `generateList`/`getSchemaFromNetworkId`/`formatToken` — passes schema validation, addresses correctly checksummed.
- [x] Confirmed `npm run build:list:monad` starts and runs without config errors (full CoinGecko crawl intentionally not run to completion — it rate-limits itself with a 5s sleep per matched token, same as other chains).
- [ ] Run full `npm run build:list:monad` before release to populate the rest of the CoinGecko-sourced tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Monad network.
  * Added native MON and Wrapped MON token metadata, including symbols, logos, decimals, and identifiers.
  * Added Monad token list generation and publication documentation.
* **Bug Fixes**
  * Ensured Monad token data is sourced from the bundled list instead of remote retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->