### PR TITLE
fix: bump ExtensionPrimitiveValue maxLength 84 -> 90

### DIFF
--- a/src/schemas/evmSchema.js
+++ b/src/schemas/evmSchema.js
@@ -14,7 +14,7 @@ const valueStringIndex =
   );
 evmSchema.definitions.ExtensionPrimitiveValue.anyOf[valueStringIndex] = {
   ...evmSchema.definitions.ExtensionPrimitiveValue.anyOf[valueStringIndex],
-  maxLength: 84,
+  maxLength: 90,
 };
 
 evmSchema.definitions.ExtensionPrimitiveValue.anyOf.push({


### PR DESCRIPTION
## Summary
- Build was failing schema validation on a token's `extensions.coingeckoId` value: `"investment-managers-series-trust-ii-tradr-2x-short-tsla-daily-etf-dinari-tokenized-etf"` (86 chars) exceeded the `ExtensionPrimitiveValue` string cap of 84 chars.
- Bumps the cap from 84 to 90 to give a bit of margin above the value that triggered this.

## Test plan
- [x] Verified the failing value now validates against the schema directly (Ajv, `ExtensionPrimitiveValue` definition)
- [x] Confirmed no other `maxLength: 84` occurrences elsewhere in `src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the maximum supported length for string extension values from 84 to 90 characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->