### PR TITLE
ci: reuse the release PR's build instead of rebuilding on tag

### DIFF
--- a/.github/workflows/release-pr-cron.yml
+++ b/.github/workflows/release-pr-cron.yml
@@ -29,11 +29,21 @@ jobs:
       - run: npm test
       - name: Bump version and commit
         run: npm run release -- --ci -i patch --no-git.tag --no-git.push --no-github.release --no-npm.publish --no-git.requireCleanWorkingDir
+      - name: Resolve version
+        run: echo "VERSION=$(node -p "require('./package.json').version")" >> "$GITHUB_ENV"
+      # Persist the built lists so release-tag.yml can attach them to the
+      # GitHub Release without re-running this ~3h build on the same commit.
+      # build/ is gitignored, so an artifact is the only way to carry it over.
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: token-lists-v${{ env.VERSION }}
+          path: build/
+          retention-days: 14
       - name: Push release branch and open PR
         env:
           GH_TOKEN: ${{ secrets.SW_PUBLIC_REPOS_GITHUB_TOKEN }}
         run: |
-          VERSION=$(node -p "require('./package.json').version")
           BRANCH="release/v$VERSION"
           git checkout -b "$BRANCH"
           git push -u origin "$BRANCH"

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # Needed to look up and download the build artifact produced by the
+      # release-pr-cron run.
+      actions: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -20,15 +23,48 @@ jobs:
         with:
           node-version: 20
       - run: npm ci
-      - run: npm run build
+      - name: Resolve version
+        run: echo "VERSION=$(node -p "require('./package.json').version")" >> "$GITHUB_ENV"
+      # release-pr-cron.yml already built these lists (~3h) on this exact
+      # commit and uploaded them. Reuse that output instead of rebuilding.
+      # Looked up by artifact name rather than by branch: the cron run is
+      # triggered on main and creates release/vX.Y.Z during the run, so its
+      # recorded head_branch is main, not the release branch.
+      - name: Locate build artifact from the release PR run
+        id: artifact
+        env:
+          GH_TOKEN: ${{ secrets.SW_PUBLIC_REPOS_GITHUB_TOKEN }}
+        run: |
+          RUN_ID=$(gh api "repos/$GITHUB_REPOSITORY/actions/artifacts?name=token-lists-v$VERSION" \
+            --jq '.artifacts | map(select(.expired == false)) | .[0].workflow_run.id // empty')
+          if [ -n "$RUN_ID" ]; then
+            echo "Reusing build from run $RUN_ID"
+            echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
+          else
+            echo "No usable artifact for v$VERSION (missing or past retention) — rebuilding."
+          fi
+      - name: Download build artifact
+        if: steps.artifact.outputs.run_id != ''
+        uses: actions/download-artifact@v4
+        with:
+          name: token-lists-v${{ env.VERSION }}
+          path: build/
+          run-id: ${{ steps.artifact.outputs.run_id }}
+          github-token: ${{ secrets.SW_PUBLIC_REPOS_GITHUB_TOKEN }}
+      # Fallback so a release is never blocked outright if the artifact
+      # expired (e.g. the release PR sat unmerged past retention).
+      - name: Rebuild token lists (fallback)
+        if: steps.artifact.outputs.run_id == ''
+        run: npm run build
         env:
           JUP_TOKEN: ${{ secrets.JUP_TOKEN }}
+      # Reads from build/, so this validates the downloaded artifact rather
+      # than trusting it.
       - run: npm test
       - name: Tag and create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.SW_PUBLIC_REPOS_GITHUB_TOKEN }}
         run: |
-          VERSION=$(node -p "require('./package.json').version")
           gh release create "v$VERSION" \
             build/*.tokenlist.json \
             build/sonarwatch.tokenlists.json \


### PR DESCRIPTION
## Problem

Both release workflows run the full `npm run build` — the ~3h job that fetches token metadata per chain:

- **`release-pr-cron.yml`** (monthly) builds + tests, then bumps the version and opens the `release/vX.Y.Z` PR.
- **`release-tag.yml`** (on that PR's merge) rebuilds **the same commit from scratch**, purely to have `build/*.tokenlist.json` files to attach to the GitHub Release.

Same commit, same inputs, ~3h build run twice back to back — ~6h per release.

## Fix

`release-pr-cron` uploads `build/` as a workflow artifact; `release-tag` downloads it instead of rebuilding. (`build/` is gitignored, so an artifact is the only way to carry it between runs.)

Release pipeline drops from ~6h to ~3h.

## Notes

- **Artifact is looked up by name, not by branch.** The cron run is triggered on `main` and creates `release/vX.Y.Z` *during* the run, so its recorded `head_branch` is `main` — a `--branch release/v$VERSION` filter would match nothing. Uses `GET /actions/artifacts?name=…` and reads `workflow_run.id` off the result.
- **Rebuild fallback retained.** If no usable artifact is found (never uploaded, or past the 14-day retention because the release PR sat unmerged), `release-tag` falls back to building — a release is never blocked outright.
- **`npm test` still runs against `build/`**, so the downloaded artifact is validated rather than trusted.
- Adds `actions: read` permission to `release-tag`, required to list/download an artifact from another run.

## Verification

- Both workflow files parse as valid YAML.
- The `?name=` API filter and the `jq` extraction (`.artifacts | map(select(.expired == false)) | .[0].workflow_run.id // empty`) were checked against the live GitHub API and against GitHub's documented artifact schema, including the empty-result case that triggers the fallback and the expired-artifact case that must be skipped.
- Not end-to-end verifiable before merge: the merge-triggered path only runs on a real `release/*` PR merge. First real exercise will be the next monthly release — confirm `release-tag` shows "Reusing build from run …" and skips the build step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release automation by preserving the package version across workflow steps.
  * Added versioned build artifacts with 14-day retention.
  * Release workflows now reuse available build artifacts when possible and rebuild them when unavailable.
  * Updated release validation to test the resulting build before publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->