### PR TITLE
ci: simplify release flow

### DIFF
--- a/.github/workflows/release-pr-cron.yml
+++ b/.github/workflows/release-pr-cron.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: "0 0 1 * *"
 
+concurrency:
+  group: open-monthly-release-pr
+  cancel-in-progress: false
+
 jobs:
   open-release-pr:
     runs-on: ubuntu-latest
@@ -14,31 +18,35 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.SW_PUBLIC_REPOS_GITHUB_TOKEN }}
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - name: git config
+      - name: Prepare version bump
+        id: version
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-      - run: npm ci
-      - run: npm run build
-        env:
-          JUP_TOKEN: ${{ secrets.JUP_TOKEN }}
-      - run: npm test
-      - name: Bump version and commit
-        run: npm run release -- --ci -i patch --no-git.tag --no-git.push --no-github.release --no-npm.publish --no-git.requireCleanWorkingDir
-      - name: Push release branch and open PR
-        env:
-          GH_TOKEN: ${{ secrets.SW_PUBLIC_REPOS_GITHUB_TOKEN }}
-        run: |
+          npm --no-git-tag-version --ignore-scripts version patch
           VERSION=$(node -p "require('./package.json').version")
-          BRANCH="release/v$VERSION"
-          git checkout -b "$BRANCH"
-          git push -u origin "$BRANCH"
-          gh pr create \
-            --base main \
-            --head "$BRANCH" \
-            --title "Release v$VERSION" \
-            --body "Automated monthly release PR. Merging this will tag \`v$VERSION\` and publish the GitHub Release with the built token lists."
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "branch=release/v$VERSION" >> "$GITHUB_OUTPUT"
+      - name: Create signed release PR
+        id: release-pr
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ github.token }}
+          sign-commits: true
+          add-paths: |
+            package.json
+            package-lock.json
+          base: main
+          branch: ${{ steps.version.outputs.branch }}
+          commit-message: Release ${{ steps.version.outputs.version }}
+          title: Release ${{ steps.version.outputs.version }}
+          body: Automated monthly release.
+      - name: Verify signed release commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMIT_SHA: ${{ steps.release-pr.outputs.pull-request-head-sha }}
+        run: |
+          test -n "$COMMIT_SHA"
+          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$COMMIT_SHA" --jq '.commit.verification.verified')" = "true"

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -55,6 +55,25 @@ jobs:
             exit 1
           fi
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+      - name: Check out merged release commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          persist-credentials: false
+      - name: Resolve merged release source
+        env:
+          EXPECTED_SOURCE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          SOURCE_SHA=$(git rev-parse HEAD)
+          MERGED_VERSION=$(node -p "require('./package.json').version")
+          if [ -z "$EXPECTED_SOURCE_SHA" ] || [ "$SOURCE_SHA" != "$EXPECTED_SOURCE_SHA" ]; then
+            echo "Checked-out release source $SOURCE_SHA does not match merged commit $EXPECTED_SOURCE_SHA."
+            exit 1
+          fi
+          if [ "$MERGED_VERSION" != "$VERSION" ]; then
+            echo "Merged release version $MERGED_VERSION does not match validated pull request version $VERSION."
+            exit 1
+          fi
           echo "SOURCE_SHA=$SOURCE_SHA" >> "$GITHUB_ENV"
       - name: Verify release does not exist
         env:

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -14,11 +14,31 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: main
-          token: ${{ secrets.SW_PUBLIC_REPOS_GITHUB_TOKEN }}
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+      - name: Resolve release metadata
+        env:
+          RELEASE_BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          SOURCE_SHA=$(git rev-parse HEAD)
+          if [ "$RELEASE_BRANCH" != "release/v$VERSION" ]; then
+            echo "Release branch $RELEASE_BRANCH does not match package version $VERSION."
+            exit 1
+          fi
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "SOURCE_SHA=$SOURCE_SHA" >> "$GITHUB_ENV"
+      - name: Verify release does not exist
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "v$VERSION" >/dev/null 2>&1; then
+            echo "Release v$VERSION already exists."
+            exit 1
+          fi
       - run: npm ci
       - run: npm run build
         env:
@@ -26,12 +46,11 @@ jobs:
       - run: npm test
       - name: Tag and create GitHub Release
         env:
-          GH_TOKEN: ${{ secrets.SW_PUBLIC_REPOS_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          VERSION=$(node -p "require('./package.json').version")
           gh release create "v$VERSION" \
             build/*.tokenlist.json \
             build/sonarwatch.tokenlists.json \
-            --title "v$VERSION" \
+            --title "Release $VERSION" \
             --generate-notes \
-            --target main
+            --target "$SOURCE_SHA"

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -14,17 +14,42 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: Resolve release metadata
         env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_SOURCE_SHA: ${{ github.event.pull_request.head.sha }}
+          RELEASE_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          RELEASE_PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           RELEASE_BRANCH: ${{ github.event.pull_request.head.ref }}
+          TRUSTED_AUTOMATION_LOGIN: github-actions[bot]
         run: |
-          VERSION=$(node -p "require('./package.json').version")
           SOURCE_SHA=$(git rev-parse HEAD)
+          if [ "$SOURCE_SHA" != "$EXPECTED_SOURCE_SHA" ]; then
+            echo "Checked-out source $SOURCE_SHA does not match pull request head $EXPECTED_SOURCE_SHA."
+            exit 1
+          fi
+          if [ "$RELEASE_HEAD_REPOSITORY" != "$GITHUB_REPOSITORY" ]; then
+            echo "Release pull request head repository $RELEASE_HEAD_REPOSITORY is not trusted."
+            exit 1
+          fi
+          if [ "$RELEASE_PR_AUTHOR" != "$TRUSTED_AUTOMATION_LOGIN" ]; then
+            echo "Release pull request author $RELEASE_PR_AUTHOR is not trusted."
+            exit 1
+          fi
+
+          COMMITTER=$(gh api "repos/$GITHUB_REPOSITORY/commits/$SOURCE_SHA" --jq '.committer.login // ""')
+          VERIFIED=$(gh api "repos/$GITHUB_REPOSITORY/commits/$SOURCE_SHA" --jq '.commit.verification.verified')
+          if [ "$COMMITTER" != "$TRUSTED_AUTOMATION_LOGIN" ] || [ "$VERIFIED" != "true" ]; then
+            echo "Release commit $SOURCE_SHA is not a verified $TRUSTED_AUTOMATION_LOGIN commit."
+            exit 1
+          fi
+
+          VERSION=$(node -p "require('./package.json').version")
           if [ "$RELEASE_BRANCH" != "release/v$VERSION" ]; then
             echo "Release branch $RELEASE_BRANCH does not match package version $VERSION."
             exit 1

--- a/src/helpers/getTokensFromCurrentList.js
+++ b/src/helpers/getTokensFromCurrentList.js
@@ -1,9 +1,6 @@
 const { default: axios } = require("axios");
 
 module.exports = async function getTokensFromCurrentList(networkId) {
-  // temp till we have a list
-  if (networkId === "monad") return [];
-
   let currentList = await axios
     .get(
       `https://github.com/Octav-Labs/sw-token-lists/releases/latest/download/sonarwatch.${networkId}.tokenlist.json`,


### PR DESCRIPTION
## Summary

- replace the PAT-based release PR flow with GITHUB_TOKEN and a verified github-actions bot commit
- remove the duplicate three-hour build from the monthly bump workflow and build/test once after merge
- publish the release from the exact merge SHA with titles formatted as Release X.Y.Z
- fetch Monad tokens from the now-published release asset instead of returning an empty list

## Validation

- parsed both workflow files as YAML
- ran git diff --check
- verified the version bump produces 1.24.107 in package.json and package-lock.json
- loaded 26 Monad tokens through the normal current-list helper
- verified the PR commit signature on GitHub

The full token-list build was not run locally because it takes approximately three hours.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Token lists are now fetched and validated consistently across all supported networks.
  * Release automation now verifies version alignment, source commits, and existing releases before publishing.
* **Chores**
  * Monthly release preparation is serialized to prevent overlapping runs.
  * Release pull requests and tags now use more reliable automated commit and verification handling.
  * Automated releases now target the validated source revision and prevent duplicate releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->