### PR TITLE
Add USDC and mUSD to the Monad token list

### DIFF
--- a/src/tokens/monad.json
+++ b/src/tokens/monad.json
@@ -22,5 +22,27 @@
     "extensions": {
       "coingeckoId": "wrapped-monad"
     }
+  },
+  {
+    "chainId": 143,
+    "address": "0x754704Bc059F8C67012fEd69BC8A327a5aafb603",
+    "decimals": 6,
+    "name": "USDC",
+    "symbol": "USDC",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/6319/large/usdc.png",
+    "extensions": {
+      "coingeckoId": "usd-coin"
+    }
+  },
+  {
+    "chainId": 143,
+    "address": "0xacA92E438df0B2401fF60dA7E4337B687a2435DA",
+    "decimals": 6,
+    "name": "MetaMask USD",
+    "symbol": "mUSD",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/68451/large/MetaMask-mUSD-Icon-200x200.png",
+    "extensions": {
+      "coingeckoId": "metamask-usd"
+    }
   }
 ]


### PR DESCRIPTION
Adds two tokens to `src/tokens/monad.json` that are missing from the CoinGecko-derived Monad feed:

- Circle USDC — `0x754704Bc059F8C67012fEd69BC8A327a5aafb603`
- MetaMask USD (mUSD) — `0xacA92E438df0B2401fF60dA7E4337B687a2435DA`

Metadata verified on-chain via `name()`/`symbol()`/`decimals()` (both 6 decimals). Both are tracked by CoinGecko (`usd-coin`, `metamask-usd`) and DefiLlama; both back active Uniswap v4 pools on Monad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing USDC and MetaMask USD tokens on chain 143.
  * Included token symbols, logos, decimal precision, contract addresses, and market identifiers.
